### PR TITLE
Update to codee version 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ axum = { version = "0.7", default-features = false, features = [
     "ws",
 ], optional = true }
 futures = { version = "0.3", default-features = false, optional = true }
-codee = { version = "0.2", features = ["json_serde"] }
+codee = { version = "0.3", features = ["json_serde"] }
 tokio = { version = "1.38.0", optional = true, features = ["rt-multi-thread"] }
 
 [features]


### PR DESCRIPTION
When attempting to compile 
`leptos_ws = "0.7.7"`
with 
`leptos = { version = "=0.7.7", features = ["nightly"] }`
causes a lot of issues, leptos_server and leptos_use seems to use codee `v0.3.0` so the traits we are putting at trait bounds from codee `v0.2.0` is not the same, for my usecase the following changeset did the trick, let me know if there is anything else we should consider for any other usecase.

This is similar to the pr submitted to leptos_i18n https://github.com/Baptistemontan/leptos_i18n/pull/218
