### PR TITLE
feature: Make it possible to create websocket signals from where leptos context is un-avialable

### DIFF
--- a/src/bidirectional/mod.rs
+++ b/src/bidirectional/mod.rs
@@ -20,7 +20,18 @@ mod server;
 /// ```rust,ignore
 /// // Create a bidirectional signal named "count_bi"
 /// let count_bi = BiDirectionalSignal::<i32>::new("count_bi", 0).unwrap();
+/// ```
+/// On the server, if outside of a leptos server function context, eg in an Actix or Axum
+/// handler:
+/// ```rust
+/// #[cfg(feature = "ssr")]
+/// use leptos_ws::BiDirectionalSignal;
+/// # fn get_signals_from_actix_or_axum() -> leptos_ws::WsSignals { leptos_ws::WsSignals::new() }
+/// let mut signals = get_signals_from_actix_or_axum(); // get it from app state
+/// let count_bi = BiDirectionalSignal::<i32>::new_with_context(&mut signals, "count_bi", 0).unwrap();
+/// ```
 ///
+/// ```rust,ignore
 /// // On the client: update the value
 /// count_bi.update(|value| *value += 1);
 ///

--- a/src/bidirectional/server.rs
+++ b/src/bidirectional/server.rs
@@ -96,6 +96,12 @@ where
 {
     pub fn new(name: &str, value: T) -> Result<Self, Error> {
         let mut signals = use_context::<WsSignals>().ok_or(Error::MissingServerSignals)?;
+        Self::new_with_context(&mut signals, name, value)
+    }
+
+    // Can be called in regular actix or axum handlers passing in the WsSignals that are kept in
+    // the app-state
+    pub fn new_with_context(signals: &mut WsSignals, name: &str, value: T) -> Result<Self, Error> {
         if signals.contains(&name) {
             return Ok(signals
                 .get_signal::<ServerBidirectionalSignal<T>>(name)

--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -20,7 +20,18 @@ mod server;
 /// ```rust,ignore
 /// // Create a channel signal named "echo"
 /// let echo_channel = ChannelSignal::<String>::new("echo").unwrap();
+/// ```
+/// On the server, if outside of a leptos server function context, eg in an Actix or Axum
+/// handler:
+/// ```rust
+/// #[cfg(feature = "ssr")]
+/// use leptos_ws::ChannelSignal;
+///     # fn get_signals_from_actix_or_axum() -> leptos_ws::WsSignals { leptos_ws::WsSignals::new() }
+///     let mut signals = get_signals_from_actix_or_axum(); // get it from app state
+///     let echo_channel = ChannelSignal::<String>::new_with_context(&mut signals, "echo").unwrap();
+/// ```
 ///
+/// ```rust,ignore
 /// // On the client: listen for messages from the server
 /// echo_channel.on_client(move |msg: &String| {
 ///     // Handle incoming message

--- a/src/channel/server.rs
+++ b/src/channel/server.rs
@@ -55,6 +55,10 @@ where
 {
     pub fn new(name: &str) -> Result<Self, Error> {
         let mut signals = use_context::<WsSignals>().ok_or(Error::MissingServerSignals)?;
+        Self::new_with_context(&mut signals, name)
+    }
+
+    pub fn new_with_context(signals: &mut WsSignals, name: &str) -> Result<Self, Error> {
         if let Some(signal) = signals.get_channel::<ServerChannelSignal<T>>(name) {
             return Ok(signal);
         }

--- a/src/read_only/mod.rs
+++ b/src/read_only/mod.rs
@@ -19,7 +19,18 @@ mod server;
 /// ```rust,ignore
 /// #[cfg(feature = "ssr")]
 /// fn create_server_signal() -> ReadOnlySignal<i32> {
-///     ReadOnlySignal::new("counter", 0)
+///     ReadOnlySignal::new("counter", 0).unwrap()
+/// }
+/// ```
+/// On the server, while outside of a leptos server function context, eg in an Actix or Axum
+/// handler:
+/// ```rust
+/// #[cfg(feature = "ssr")]
+/// use leptos_ws::ReadOnlySignal;
+/// fn create_server_signal() -> ReadOnlySignal<i32> {
+///     # fn get_signals_from_actix_or_axum() -> leptos_ws::WsSignals { leptos_ws::WsSignals::new() }
+///     let mut signals = get_signals_from_actix_or_axum(); // get it from app state
+///     ReadOnlySignal::new_with_context(&mut signals, "counter", 0).unwrap()
 /// }
 /// ```
 ///

--- a/src/read_only/server.rs
+++ b/src/read_only/server.rs
@@ -90,6 +90,10 @@ where
 {
     pub fn new(name: &str, value: T) -> Result<Self, Error> {
         let mut signals = use_context::<WsSignals>().ok_or(Error::MissingServerSignals)?;
+        Self::new_with_context(&mut signals, name, value)
+    }
+
+    pub fn new_with_context(signals: &mut WsSignals, name: &str, value: T) -> Result<Self, Error> {
         if signals.contains(&name) {
             return Ok(signals.get_signal::<ServerReadOnlySignal<T>>(name).unwrap());
         }


### PR DESCRIPTION
### Background
Currently its possbile to get a signal handle with `WsSignals::get_signal()` this has been enough for me to update state of a signal from outside of the leptos-server functions with just a handle to `WsSignals`.
However this method relies on something from the leptos world having "touched" the signal first, as this way of accessing a signal will never create it. Furthermore, it looks to be seemingly impossible to create and register a signal currently with just the `WsSignals` handle, just via the `::new()` function will you be able too instanciate it appropriatly, however, `::new()` will crash in these contexts, as there would be no context to read from.

### Changes
This pr attempts to make it possible to work with the signals from outside of where "provide context" works. without a component referencing the signal or a server function referencing the signal first having been called. (stuff like regular axum handlers where my usecase (not the server function kind, as my usecase requires both), but stuff like backround threads also comes to mind as a potential usecase)

I had a hard time naming these functions, very open to suggestions on the naming. preferably something that will communicate that its prefered to use the regular `::new()` for most usecases, and that this is an escape hatch to allow use in axum and actix handlers (not the server function kind).

I do see one possible downside of this api that code sharing between for example a compoent, and for example a tokio thread background loop will not be as clean. Also open to suggestions to how we might be able to re-strure the code to allow the frontend to also pass the signals context to aliviate this issue.

